### PR TITLE
pursuing candidate chimeric alignments that do not overlap on the ref…

### DIFF
--- a/main.c
+++ b/main.c
@@ -78,7 +78,7 @@ static ko_longopt_t long_options[] = {
 	{ "no-hash-name",   ko_no_argument,       353 },
 	{ "secondary-seq",  ko_no_argument,       354 },
     { "only_chimeric",  ko_no_argument,       355 },
-    { "max-chimeric-ov",ko_required_argument, 'z' },
+    { "min-overlap-non-chimeric",ko_required_argument, 356 },
 	{ "help",           ko_no_argument,       'h' },
 	{ "max-intron-len", ko_required_argument, 'G' },
 	{ "version",        ko_no_argument,       'V' },
@@ -137,6 +137,11 @@ int main(int argc, char *argv[])
 	mm_realtime0 = realtime();
 	mm_set_opt(0, &ipt, &opt);
 
+    // init defaults for opts
+    opt.only_chimeric_candidates = 0;
+    opt.min_overlap_non_chimeric = 0.25;
+    
+
 	while ((c = ketopt(&o, argc, argv, 1, opt_str, long_options)) >= 0) { // test command line options and apply option -x/preset first
 		if (c == 'x') {
 			if (mm_set_opt(o.arg, &ipt, &opt) < 0) {
@@ -182,7 +187,6 @@ int main(int argc, char *argv[])
 		else if (c == 'B') opt.b = atoi(o.arg);
 		else if (c == 'b') opt.transition = atoi(o.arg);
 		else if (c == 's') opt.min_dp_max = atoi(o.arg);
-        else if (c == 'z') opt.max_overlap_in_chimeric = atof(o.arg);
 		else if (c == 'C') opt.noncan = atoi(o.arg);
 		else if (c == 'I') ipt.batch_size = mm_parse_num(o.arg);
 		else if (c == 'K') opt.mini_batch_size = mm_parse_num(o.arg);
@@ -247,6 +251,7 @@ int main(int argc, char *argv[])
 		else if (c == 353) opt.flag |= MM_F_NO_HASH_NAME; // --no-hash-name
 		else if (c == 354) opt.flag |= MM_F_SECONDARY_SEQ; // --secondary-seq
         else if (c == 355) opt.only_chimeric_candidates = 1;
+        else if (c == 356) opt.min_overlap_non_chimeric = atof(o.arg);
 		else if (c == 330) {
 			fprintf(stderr, "[WARNING] \033[1;31m --lj-min-ratio has been deprecated.\033[0m\n");
 		} else if (c == 314) { // --frag
@@ -378,7 +383,13 @@ int main(int argc, char *argv[])
 		fprintf(fp_help, "                 - asm5/asm10/asm20 - asm-to-ref mapping, for ~0.1/1/5%% sequence divergence\n");
 		fprintf(fp_help, "                 - splice/splice:hq - long-read/Pacbio-CCS spliced alignment\n");
 		fprintf(fp_help, "                 - sr - genomic short-read mapping\n");
-		fprintf(fp_help, "\nSee `man ./minimap2.1' for detailed description of these and other advanced command-line options.\n");
+        fprintf(fp_help, "\n");
+        fprintf(fp_help, "  Chimeric settings:\n");
+        fprintf(fp_help, "    --only_chimeric   :only pursue those transcripts that are chimeric alignment candidates.\n");
+        fprintf(fp_help, "    --min-overlap-non-chimeric FLOAT :only those same-transcript alignments to diff loci overlapping by \n");
+        fprintf(fp_help, "                 this fraction of the query length are considered evidence for chimeras (default: 0.25)\n"); 
+        fprintf(fp_help, "\n");
+     	fprintf(fp_help, "\nSee `man ./minimap2.1' for detailed description of these and other advanced command-line options.\n");
 		return fp_help == stdout? 0 : 1;
 	}
 

--- a/map.c
+++ b/map.c
@@ -226,64 +226,147 @@ static mm_reg1_t *align_regs(const mm_mapopt_t *opt, const mm_idx_t *mi, void *k
 
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
-#define CHIMERIC_USE_REF 0
+
 
 inline int interval_match(const uint32_t start1, const uint32_t end1, const uint32_t start2, const uint32_t end2) {
     return (start1 == start2) && (end1 == end2);
 }
 
-inline int interval_overlap(const uint32_t start1, const uint32_t end1, const uint32_t start2, const uint32_t end2,
-                            const float min_overlap) {
-    // returns 1 if the intervals overlap and overlap_size/min_interval_size > min_overlap
-    if ((start1 <= end2) && (start2 <= end1)) {
-        if (min_overlap == 0) return 1;
-        if (mm_dbg_flag) {
-            fprintf(stderr, "overlap delta=%d\tratio=%f\n", MIN(end1, end2) - MAX(start1, start2),
-                    (float) (MIN(end1, end2) - MAX(start1, start2)) / (float) MIN((end1 - start1), (end2 - start2)));
-        }
-        return (float) (MIN(end1, end2) - MAX(start1, start2)) / (float) MIN((end1 - start1), (end2 - start2)) > min_overlap;
+inline float interval_overlap(const uint32_t start1, const uint32_t end1, const uint32_t start2, const uint32_t end2) {
+
+    // returns fraction of overlap of the shorter alignment range
+    if ((start1 <= end2) && (end1 >= start2)) {
+        // segs overlap
+
+        int delta =  (MIN(end1, end2) - MAX(start1, start2));
+        float shortest_align_len = (float) MIN((end1 - start1), (end2 - start2));
+        float ratio = (float) delta/shortest_align_len;
+        if (mm_dbg_flag) 
+            fprintf(stderr, "overlap delta=%d\tratio=%f\n", delta, shortest_align_len);
+        
+        return(ratio);
     }
-    return 0;
+    
+    return 0.0;
 }
 
-inline int is_non_chimeric(const int n_regs0, const mm_reg1_t *regs0, const mm128_t *a, const mm_mapopt_t *opt) {
+inline int is_non_chimeric(const char* qname, const int n_regs0, const mm_reg1_t *regs0, const mm128_t *a, const mm_mapopt_t *opt) {
     // returns 1 iff the matches are not potentially chimeric:
     // 1. if we only have a single chain
     // 2. if all the matches correspond either to the same read region (repetitive hits)
     // or reference region (duplicated sequence within the read)
-    if (n_regs0 == 1) return 1;
-    //if (opt->max_overlap_in_chimeric >= 1) return 0;
+    if (n_regs0 == 1) {
+        if (mm_dbg_flag)
+            fprintf(stderr, 
+                    "IS_NON_CHIMERIC\t%s\tSINGLE\t-1.0\n",
+                    qname);
+
+        return 1;
+    }
+    if (opt->min_overlap_non_chimeric <= 0) {
+        // default is 1 where this method is always run when multiple hits are present.
+        // if zero, then dont run this method, just return it as being potentially chimeric.
+        if (mm_dbg_flag)
+            fprintf(stderr, 
+                    "IS_NON_CHIMERIC\t%s\tMULT\t-1.0\n",
+                    qname);
+        
+        return 0; // continue to explore as chimera candidate.
+    }
+    
     // check if all the matches correspond to the same read or reference regions
-    for (int i = 1; i < n_regs0; ++i) {
-        const uint32_t q_start_prev = a[regs0[i-1].as].y, q_end_prev = a[regs0[i-1].as + regs0[i-1].cnt - 1].y;
-        const uint32_t q_start_curr = a[regs0[i].as].y, q_end_curr = a[regs0[i].as + regs0[i].cnt - 1].y;
-        const uint32_t r_start_prev = a[regs0[i-1].as].x, r_end_prev = a[regs0[i-1].as + regs0[i-1].cnt - 1].x;
-        const uint32_t r_start_curr = a[regs0[i].as].x, r_end_curr = a[regs0[i].as + regs0[i].cnt - 1].x;
-        const uint8_t tid_prev = (a[regs0[i-1].as].x << 1) >> 33, tid_curr = (a[regs0[i].as].x << 1) >> 33;
+
+    // if there exist at least two alignment chains that:
+    // - dont overlap on the genome
+    // - overlap less than min_overlap_non_chimeric
+    // then return chimeric (0)
+    // else non-chimeric (1)
+    
+    
+    float max_frac_overlap = -1.0; // set as neg1 so clear its not being used when frac overlap check is skipped altogether.
+    int i;
+    for (i = 1; i < n_regs0; ++i) {
+        
+        // query transcript coordinates
+        const uint32_t q_start_prev = regs0[i-1].qs; // a[regs0[i-1].as].y;
+        const uint32_t q_end_prev = regs0[i-i].qe; // a[regs0[i-1].as + regs0[i-1].cnt - 1].y;
+        
+        const uint32_t q_start_curr =  regs0[i].qs; //a[regs0[i].as].y;
+        const uint32_t q_end_curr =  regs0[i].qe; //a[regs0[i].as + regs0[i].cnt - 1].y;
+
+        // ref genome coordinates
+        const uint32_t r_start_prev = regs0[i-1].rs; //   a[regs0[i-1].as].x;
+        const uint32_t r_end_prev =regs0[i-1].re; //  a[regs0[i-1].as + regs0[i-1].cnt - 1].x;
+        
+        const uint32_t r_start_curr = regs0[i].rs; //a[regs0[i].as].x;
+        const uint32_t r_end_curr = regs0[i].re; //a[regs0[i].as + regs0[i].cnt - 1].x;
+        
+        // chrom info
+        const uint8_t tid_prev = (a[regs0[i-1].as].x << 1) >> 33;
+        const uint8_t tid_curr = (a[regs0[i].as].x << 1) >> 33;
+        
+        // exclude comparisions where the alignments overlap on the genome
+        if (tid_prev == tid_curr) { // same chromosome
+            if (r_start_prev < r_end_curr && r_end_prev > r_start_curr) {
+                // overlaps on the genome. Skip.
+                continue;
+            }
+        }
+        
         if (mm_dbg_flag) {
-            fprintf(stderr, "checking coords %d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+            fprintf(stderr, "checking coords %s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+                    qname,
                     tid_prev, r_start_prev, r_end_prev, tid_curr, r_start_curr, r_end_curr,
                     q_start_prev, q_end_prev, q_start_curr, q_end_curr);
         }
-        if (interval_match(q_start_prev, q_end_prev, q_start_curr, q_end_curr)) continue;
-        if (opt->max_overlap_in_chimeric < 1 && interval_overlap(q_start_prev, q_end_prev,
-                                                                 q_start_curr, q_end_curr,
-                                                                 opt->max_overlap_in_chimeric)) continue;
-        if (CHIMERIC_USE_REF && tid_prev == tid_curr) {
-            if (mm_dbg_flag)
-                fprintf(stderr, "reference\n");
-            if (interval_match(r_start_prev, r_end_prev, r_start_curr, r_end_curr)) continue;
-            if (opt->max_overlap_in_chimeric < 1 && interval_overlap(r_start_prev, r_end_prev,
-                                                                     r_start_curr, r_end_curr,
-                                                                     opt->max_overlap_in_chimeric)) continue;
+        if (interval_match(q_start_prev, q_end_prev, q_start_curr, q_end_curr)) {
+            if (mm_dbg_flag) {
+                fprintf(stderr, "\t* %s query EXACT interval MATCH identified - skipping as chimera evidence.\n", qname);
+            }
+            continue;
         }
-        return 0; // at least two regions did not match/overlap in both the read and the reference
+        if (opt->min_overlap_non_chimeric < 1) {
+            // more rigorus search of overlap than the above exact coordinate matching.
+
+            float frac_overlap_shortest_alignment = interval_overlap(q_start_prev, q_end_prev,
+                                                                     q_start_curr, q_end_curr);
+
+            max_frac_overlap = MAX(frac_overlap_shortest_alignment, max_frac_overlap);
+            if (frac_overlap_shortest_alignment >= opt->min_overlap_non_chimeric) {
+                if (mm_dbg_flag) 
+                    fprintf(stderr, "\t* %s query interval %.3f OVERLAP identified - skipping as chimera evidence.\n", qname, frac_overlap_shortest_alignment);
+               
+                continue;
+            }
+                                    
+        }
+        
+        // if get here:
+        // have at least two alignments meeting chimera candidate evidence.
+        // - not overlapping on the ref genome
+        // - overlapping by < min_overlap_non_chimeric setting.
+    
+        if (mm_dbg_flag) {
+            fprintf(stderr, "is_non_chimeric() - %s IS chimera candidate. Max frac query overlap: %.3f\n", qname, max_frac_overlap);
+            fprintf(stderr, 
+                    "IS_NON_CHIMERIC\t%s\tMULT\t%.3f\n",
+                    qname, max_frac_overlap);
+        }
+        return 0; // potentially chimeric (not is_not_chimeric)
         // note: this is still permissive since it checks for consecutive pair overlaps only and
         // can be further restricted by considering all-pair overlaps and counting connected components
         // or sorting the chains
     }
-    return 1;
+    
+    if (mm_dbg_flag) {
+        fprintf(stderr, "is_non_chimeric() - %s NOT chimera candidate. Max frac query overlap: %.3f\n", qname, max_frac_overlap);
+        fprintf(stderr, 
+                "IS_NON_CHIMERIC\t%s\tMULT\t%.3f\n",
+                qname, max_frac_overlap);
+    }
+    return 1; // not chimeric
 }
+
 
 void mm_map_frag(const mm_idx_t *mi, int n_segs, const int *qlens, const char **seqs, int *n_regs, mm_reg1_t **regs, mm_tbuf_t *b, const mm_mapopt_t *opt, const char *qname)
 {
@@ -409,7 +492,7 @@ void mm_map_frag(const mm_idx_t *mi, int n_segs, const int *qlens, const char **
 
     if (mm_dbg_flag) fprintf(stderr, "NREGS0_after_chain_post:\t%d\t%s\n", n_regs0, qname);
 
-    if (opt->only_chimeric_candidates && is_non_chimeric(n_regs0, regs0, a, opt)) {
+    if (opt->only_chimeric_candidates && is_non_chimeric(qname, n_regs0, regs0, a, opt)) {
         if (mm_dbg_flag)
             fprintf(stderr, "-skipping further alignment of non-chimeric %s\n", qname);
 
@@ -417,14 +500,22 @@ void mm_map_frag(const mm_idx_t *mi, int n_segs, const int *qlens, const char **
         if (mm_dbg_flag) {
             for (j = 0; j < n_regs0; ++j) {
                 const int idx_start = regs0[j].as;
-                const int idx_end = regs0[j].as + regs0[j].cnt - 1;
+                //const int idx_end = regs0[j].as + regs0[j].cnt - 1;
                 fprintf(stderr, "CN-CHIMERIC\t%s\t%d\t%s\t%d\t%d\t%c\t%d\t%d\n",
                         qname, j, mi->seq[a[idx_start].x << 1 >> 33].name,
+                        
+                        /*
                         (int32_t) a[idx_start].x,
                         (int32_t) a[idx_end].x,
                         "+-"[a[idx_start].x >> 63],
                         (int32_t) a[idx_start].y,
                         (int32_t) a[idx_end].y);
+                        */
+                        (int32_t) regs0[j].rs,
+                        (int32_t) regs0[j].re,
+                        "+-"[a[idx_start].x >> 63],
+                        (int32_t) regs0[j].qs,
+                        (int32_t) regs0[j].qe);
             }
         }
         if (n_segs == 1) { // uni-segment

--- a/minimap.h
+++ b/minimap.h
@@ -181,7 +181,7 @@ typedef struct {
 	const char *split_prefix;
 
     int only_chimeric_candidates;
-    float max_overlap_in_chimeric;
+    float min_overlap_non_chimeric;
 
 } mm_mapopt_t;
 


### PR DESCRIPTION
- pursuing candidate chimeric alignments that do not overlap on the ref genome and overlap by <  --min_overlap_non_chimeric (default 0.25)
- includes bugfix around transcript coordinate identification
- some parameter renaming and default setting
- slight refactoring and logging for downstream analysis